### PR TITLE
warn the user if they don't have X509_USER_PROXY set

### DIFF
--- a/jobSubmission/submitCMSSWCondorJobs.py
+++ b/jobSubmission/submitCMSSWCondorJobs.py
@@ -45,6 +45,10 @@ if __name__ == "__main__":
         print 'You have to run from the BPH_RDntuplizer directory'
         exit()
 
+    if 'X509_USER_PROXY' not in os.environ:
+	print "X509_USER_PROXY environment variable not set"
+	exit(1)
+
     '''
     ######################## Prepare output ###################################
     '''


### PR DESCRIPTION
This just adds a small warning to the user if they don't have the X509_USER_PROXY environment variable set which is used later in the condor job submission file.