### PR TITLE
turn flist back into a list

### DIFF
--- a/jobSubmission/create-condor-jobs
+++ b/jobSubmission/create-condor-jobs
@@ -137,6 +137,8 @@ if __name__ == "__main__":
                 print("skipping %s because it's already done" % filename)
                 flist.remove(filename)
 
+    flist = list(flist)
+
     '''
     ###################### Check CMSSW and config ############################
     '''


### PR DESCRIPTION
I realized in my earlier testing that since I had already submitted all of the jobs it never actually got to the point in the script where it has to iterate over the list of input filenames. Although using a set sped up the checking of duplicate files, later we can't index into a set the same way as a list so we need to turn it back into one.

I haven't gotten a chance to test this since there aren't any more MC files, but will try to test it some other way soon.