### PR TITLE
add a cut on the ndof of the primary vertices

### DIFF
--- a/plugins/VtxUtils.cc
+++ b/plugins/VtxUtils.cc
@@ -674,6 +674,11 @@ vtxu::kinFitResuts vtxu::fitQuality(RefCountedKinematicTree t, double pval_thr){
     t->movePointerToTheTop();
     out.chi2 = t->currentDecayVertex()->chiSquared();
     out.dof = t->currentDecayVertex()->degreesOfFreedom();
+    if (out.chi2 < 0) {
+      fprintf(stderr, "error: vertex fit chi2 is less than zero!\n");
+      out.isGood = false;
+      return out;
+    }
     out.pval = ChiSquaredProbability(out.chi2, out.dof);
     if (pval_thr > 0) {
       out.isGood = out.pval > pval_thr;


### PR DESCRIPTION
This cut makes the local vertex density distribution between MC and data match better after reweighting on the total number of possible vertices. It also makes intuitive sense since we don't want to use primary vertices with only a few tracks.

I also added an error message to print out if the chi2 of the refitted vertex is negative.

So far I have only compile tested this, still need to run it.