### PR TITLE
speed up the ntuplizer

### DIFF
--- a/config/cmssw_centralMC_Tag_Bd_MuDst-PiPiK.py
+++ b/config/cmssw_centralMC_Tag_Bd_MuDst-PiPiK.py
@@ -138,7 +138,7 @@ process.HammerWeights = cms.EDProducer("HammerWeightsProducer",
                                     'BD(2s)', 'ISGW2',
                                     'BD(2s)*', 'ISGW2',
         ),
-        verbose = cms.int32(1)
+        verbose = cms.int32(0)
 )
 
 cfg_name = os.path.basename(sys.argv[0])

--- a/plugins/B2DstMuDecayTreeProducer.cc
+++ b/plugins/B2DstMuDecayTreeProducer.cc
@@ -517,7 +517,6 @@ void B2DstMuDecayTreeProducer::produce(edm::Event& iEvent, const edm::EventSetup
             int i_muon_PFcand = -1;
 
             for(uint i_tk = 0; i_tk < N_pfCand; ++i_tk) {
-              if (!valid[i_tk]) continue;
               // PF candidate different from K, pi and pis
               if( i_tk==i_K || i_tk==i_pi || i_tk==i_pis) continue;
 

--- a/plugins/HammerWeightsProducer.cc
+++ b/plugins/HammerWeightsProducer.cc
@@ -456,6 +456,19 @@ HammerWeightsProducer::HammerWeightsProducer(const edm::ParameterSet &iConfig)
     if (verbose) {cout << "[Hammer]: CLN central values\n\t" << centralValuesOpt << endl;}
     hammer.setOptions(centralValuesOpt);
 
+    /* Set the Wilson coefficients. From Michele:
+     *
+     *  > Btw since you are not fitting new physics wilson coefficients, did you
+     *  > specialize the WC early (as in before you loop over getWeight)? That
+     *  > would save you 2* 3^N /events matrix multiplications and small array
+     *  > allocations...
+     *
+     *  Also see section K in the Hammer guide.
+     *
+     *  This speeds up the total processing time by more than a factor of 2. */
+    hammer.specializeWCInWeights("BtoCTauNu",{{"SM", 1.0}});
+    hammer.specializeWCInWeights("BtoCMuNu",{{"SM", 1.0}});
+
     // ################# BLPR for D* ##############################
     centralValuesOpt = "BtoD*BLPRVar: {";
     for(auto i=0; i<7; i++) {


### PR DESCRIPTION
This commit speeds up the ntuplizer by a lot by pre-computing whether
tracks are valid and adding a call to specializeWCInWeights(). This
brings the total processing time of a single file from around 15 minutes
to 3 minutes.